### PR TITLE
AGP 버전 8.3.2로 변경

### DIFF
--- a/build-logic/src/main/java/com/hegunhee/maplemfinder/build_logic/setup/AndroidGradleDsl.kt
+++ b/build-logic/src/main/java/com/hegunhee/maplemfinder/build_logic/setup/AndroidGradleDsl.kt
@@ -9,13 +9,13 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.api.Project
 
-internal val Project.applicationExtension: CommonExtension<*, *, *, *>
+internal val Project.applicationExtension: CommonExtension<*, *, *, *, *, *>
     get() = extensions.getByType<ApplicationExtension>()
 
-internal val Project.libraryExtension: CommonExtension<*, *, *, *>
+internal val Project.libraryExtension: CommonExtension<*, *, *, *,*,*>
     get() = extensions.getByType<LibraryExtension>()
 
-internal val Project.androidExtension: CommonExtension<*, *, *, *>
+internal val Project.androidExtension: CommonExtension<*, *, *, *,*,*>
     get() = runCatching { libraryExtension }
         .recoverCatching { applicationExtension }
         .onFailure { println("Could not find Library or Application extension from this project") }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradleVersion = "8.0.2"
+androidGradleVersion = "8.3.2"
 kotlinGradleVersion = "1.8.10"
 androidxComposeCompiler = "1.4.3"
 org-jetbrains-kotlin-jvm = "1.8.10"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jan 12 21:07:35 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
테스트코드가 작성하지 않아 AGP를 8.3.2 버전으로 변경했습니다.
그로 인해서 gradle 도 8.4버전으로 변경했고 commonExtension 파라미터도 변경했습니다.


This closes #19 