### PR TITLE
feature:main 모듈에서 사용하지않는 애너테이션 삭제

### DIFF
--- a/feature/main/src/main/java/com/hegunhee/maplefinder/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/hegunhee/maplefinder/main/MainActivity.kt
@@ -6,10 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.hegunhee.maplefinder.maplefinder.ui.theme.MapleFinderTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -28,4 +25,5 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
 }

--- a/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
+++ b/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
@@ -43,7 +42,6 @@ import com.hegunhee.maplefinder.item.itemNavGraph
 import com.hegunhee.maplefinder.item.navigateItemDetail
 import com.hegunhee.maplefinder.item.navigateItemList
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapleApp(
     mapleAppScaffoldState: MapleAppScaffoldState = rememberMapleAppScaffoldState()
@@ -51,7 +49,10 @@ fun MapleApp(
     MapleAppDrawer(
         mapleAppScaffoldState = mapleAppScaffoldState,
         drawerSheetContent = {
-            DrawerSheetContent(selectedDrawerItem = mapleAppScaffoldState.selectedDrawerItem, onClickDrawerItem = mapleAppScaffoldState::navigate)
+            DrawerSheetContent(
+                selectedDrawerItem = mapleAppScaffoldState.selectedDrawerItem,
+                onClickDrawerItem = mapleAppScaffoldState::navigate
+            )
         }
     ) {
         NavHost(
@@ -75,14 +76,13 @@ fun MapleApp(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun rememberMapleAppScaffoldState(
     navController: NavHostController = rememberNavController(),
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
     drawerState: DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-) : MapleAppScaffoldState {
-    return remember(navController,coroutineScope,drawerState) {
+): MapleAppScaffoldState {
+    return remember(navController, coroutineScope, drawerState) {
         MapleAppScaffoldState(
             coroutineScope = coroutineScope,
             navController = navController,
@@ -91,28 +91,27 @@ fun rememberMapleAppScaffoldState(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-class MapleAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
-    val coroutineScope : CoroutineScope,
-    val navController : NavHostController,
-    val drawerState : DrawerState
+class MapleAppScaffoldState(
+    val coroutineScope: CoroutineScope,
+    val navController: NavHostController,
+    val drawerState: DrawerState
 ) {
-    fun navigate(drawerItem : DrawerItem) {
+    fun navigate(drawerItem: DrawerItem) {
         navController.navigate(drawerItem.navRoute)
         coroutineScope.launch {
             drawerState.close()
         }
     }
 
-    fun navigateItemDetail(ocid : String) {
+    fun navigateItemDetail(ocid: String) {
         navController.navigateItemDetail(ocid)
     }
 
-    fun navigateItemList(ocid : String,slotName : String) {
-        navController.navigateItemList(ocid,slotName)
+    fun navigateItemList(ocid: String, slotName: String) {
+        navController.navigateItemList(ocid, slotName)
     }
 
-    fun popBackStack()  {
+    fun popBackStack() {
         navController.popBackStack()
     }
 
@@ -135,32 +134,33 @@ class MapleAppScaffoldState @OptIn(ExperimentalMaterial3Api::class) constructor(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapleAppDrawer(
     mapleAppScaffoldState: MapleAppScaffoldState = rememberMapleAppScaffoldState(),
-    drawerSheetContent : @Composable ColumnScope.() -> Unit,
-    content : @Composable () -> Unit
+    drawerSheetContent: @Composable ColumnScope.() -> Unit,
+    content: @Composable () -> Unit
 ) {
     ModalNavigationDrawer(
         drawerState = mapleAppScaffoldState.drawerState,
-        drawerContent = { ModalDrawerSheet {
-            drawerSheetContent()
-        }}
+        drawerContent = {
+            ModalDrawerSheet {
+                drawerSheetContent()
+            }
+        }
     ) {
         content()
     }
 }
 
 enum class DrawerGroup {
-    Personal,Ranking,Others
+    Personal, Ranking, Others
 }
 
 enum class DrawerItem(
-    private val group : DrawerGroup,
-    val titleString : String,
-    @DrawableRes val iconRes : Int,
-    val navRoute : String
+    private val group: DrawerGroup,
+    val titleString: String,
+    @DrawableRes val iconRes: Int,
+    val navRoute: String
 ) {
     Info(
         group = DrawerGroup.Personal,
@@ -181,11 +181,13 @@ enum class DrawerItem(
         iconRes = com.hegunhee.maplefinder.designsystem.R.drawable.dojangicon,
         navRoute = DojangNavGraph.dojangRoute
     );
+
     companion object {
         fun ofOrNull(route: String): DrawerItem? {
             return values().firstOrNull { it.navRoute == route }
         }
     }
+
     val isLastItem: Boolean
         get() = ordinal == DrawerItem.values().lastIndex
 
@@ -193,11 +195,10 @@ enum class DrawerItem(
         get() = isLastItem || group != DrawerItem.values()[ordinal + 1].group
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DrawerSheetContent(
-    selectedDrawerItem : DrawerItem?,
-    onClickDrawerItem : (DrawerItem) -> Unit
+    selectedDrawerItem: DrawerItem?,
+    onClickDrawerItem: (DrawerItem) -> Unit
 ) {
     Column(
         modifier = Modifier.verticalScroll(rememberScrollState())
@@ -206,7 +207,12 @@ fun DrawerSheetContent(
         DrawerItem.values().forEach { drawerItem ->
             NavigationDrawerItem(
                 icon = {
-                    Icon(modifier = Modifier.size(38.dp),painter = painterResource(id = drawerItem.iconRes), contentDescription = null,tint = Color.Unspecified)
+                    Icon(
+                        modifier = Modifier.size(38.dp),
+                        painter = painterResource(id = drawerItem.iconRes),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
                 },
                 label = {
                     Text(drawerItem.titleString)
@@ -228,11 +234,22 @@ fun DrawerSheetContent(
             thickness = 1.dp,
             modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp)
         )
-        Text(modifier = Modifier.fillMaxWidth(),text = "Data based on NEXON Open API", textAlign = TextAlign.End)
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = "Data based on NEXON Open API",
+            textAlign = TextAlign.End
+        )
     }
 }
 
 @Composable
 private fun DrawerSheetHeader() {
-    Text(modifier = Modifier.fillMaxWidth().padding(10.dp), text = "Maple 정보 검색", fontSize = 30.sp, textAlign = TextAlign.Center)
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(10.dp),
+        text = "Maple 정보 검색",
+        fontSize = 30.sp,
+        textAlign = TextAlign.Center
+    )
 }


### PR DESCRIPTION
컴포즈 버전이 올라가면서 ExperimentalMaterial3Api 애노테이션을 삭제할 수 있게 되었다.

그리고 네비게이션 테스트를 진행해보려 했지만 hiltViewModel 으로 설정되어있던 viewModel 의존성 주입을 풀어내지 못해서 실패했다.
네비게이션 테스트를 해야하므로 MapleApp 컴포저블에서 시작해야 하는데
해당 컴포저블에서 시작할경우 ViewModel 관련 주입을 진행할 수 없다.

hiltTest 의존성을 추가해서 하려했지만 repository 주입을 해주는 RepositoryModule을 알기위해 data 모듈을 알아야했고
그 방법도 실패했다. 그러므로 결과적으로 성공하지 못했다.

This closes #46 