### PR TITLE
item 검색 화면 리팩터링

### DIFF
--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/CharacterSurface.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/CharacterSurface.kt
@@ -40,7 +40,7 @@ import com.hegunhee.maplefinder.ui.tag.WorldTag
 @Composable
 fun CharacterSurface(
     character : Character,
-    onItemDetailButtonClick: (String) -> Unit
+    onItemDetailButtonClick: (ocid: String,date: String) -> Unit
 ) {
     val scrollState = rememberScrollState()
     Surface(
@@ -57,6 +57,7 @@ fun CharacterSurface(
             )
             CharacterDetailButton(
                 ocid = character.ocid,
+                date = character.basic.date,
                 onItemDetailButtonClick = onItemDetailButtonClick
             )
         }
@@ -98,9 +99,10 @@ private fun ColumnScope.CharacterStat(
 @Composable
 private fun CharacterDetailButton(
     ocid : String,
-    onItemDetailButtonClick : (String) -> Unit
+    date : String,
+    onItemDetailButtonClick : (ocid: String,date: String) -> Unit
 ) {
-    Button(modifier = Modifier.fillMaxWidth(),onClick = { onItemDetailButtonClick(ocid) }) {
+    Button(modifier = Modifier.fillMaxWidth(),onClick = { onItemDetailButtonClick(ocid,date) }) {
         Text(modifier = Modifier.fillMaxWidth(),text = "착용 장비 정보 탐색", textAlign = TextAlign.Center)
     }
 }
@@ -110,7 +112,7 @@ private fun CharacterDetailButton(
 private fun CharacterSurfacePreview() {
     CharacterSurface(
         character = createCharacter(),
-        onItemDetailButtonClick = {  }
+        onItemDetailButtonClick = {ocid, date ->  }
     )
 }
 

--- a/feature/character-info/src/main/java/com/hegunhee/maplefinder/character_info/InfoScreenRoot.kt
+++ b/feature/character-info/src/main/java/com/hegunhee/maplefinder/character_info/InfoScreenRoot.kt
@@ -28,7 +28,7 @@ import com.hegunhee.maplefinder.util.SelectedDateFormatUtil.toTimeMills
 fun InfoScreenRoot(
     viewModel: InfoViewModel = hiltViewModel(),
     onNavigationIconClick: () -> Unit,
-    onItemDetailButtonClick: (String) -> Unit,
+    onItemDetailButtonClick: (ocid: String,date: String) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val (searchQuery, onQueryChanged) = rememberSaveable { mutableStateOf("") }
@@ -54,7 +54,7 @@ fun InfoScreen(
     onNavigationIconClick: () -> Unit,
     onSearchCharacterClick: (name: String, date: String) -> Unit,
     onQueryChange: (String) -> Unit,
-    onItemDetailButtonClick: (String) -> Unit,
+    onItemDetailButtonClick: (ocid: String,date: String) -> Unit,
     onDateSelected: (String) -> Unit,
 ) {
     val (showDateDialog, onDatePickerValueChange) = remember { mutableStateOf(false) }
@@ -115,7 +115,7 @@ private fun InfoScreenPreview() {
         onNavigationIconClick = {  },
         onSearchCharacterClick = {name,date->},
         onQueryChange = {  },
-        onItemDetailButtonClick = {  },
+        onItemDetailButtonClick = {ocid, date->  },
         onDateSelected = {},
     )
 }

--- a/feature/character-info/src/main/java/com/hegunhee/maplefinder/character_info/navigation/InfoNavGraph.kt
+++ b/feature/character-info/src/main/java/com/hegunhee/maplefinder/character_info/navigation/InfoNavGraph.kt
@@ -8,7 +8,7 @@ const val CHARACTER_INFO_ROUTE = "Character-Info"
 
 fun NavGraphBuilder.infoNavGraph(
     onNavigationIconClick: () -> Unit,
-    onItemDetailButtonClick: (String) -> Unit
+    onItemDetailButtonClick: (ocid: String,date: String) -> Unit
 ) {
     composable(route = CHARACTER_INFO_ROUTE) {
         InfoScreenRoot(

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailRoot.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailRoot.kt
@@ -2,10 +2,7 @@ package com.hegunhee.maplefinder.item.detail
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SelectableDates
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -15,12 +12,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hegunhee.maplefinder.ui.MapleTopBar
 import com.hegunhee.maplefinder.ui.surface.CharacterEquipmentItemSurface
 import com.hegunhee.maplefinder.ui.surface.ErrorSurface
-import com.hegunhee.maplefinder.util.SelectedDateFormatUtil
 
 @Composable
 fun ItemDetailScreenRoot(
     viewModel : ItemDetailViewModel = hiltViewModel(),
     ocid : String,
+    date : String,
     onNavigationIconClick : () -> Unit,
     onItemListButtonClick : (String,String) -> Unit
 ) {

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
@@ -1,4 +1,4 @@
-package com.hegunhee.maplefinder.item
+package com.hegunhee.maplefinder.item.navigation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -9,12 +9,22 @@ import com.hegunhee.maplefinder.item.detail.ItemDetailScreenRoot
 import com.hegunhee.maplefinder.item.list.ItemListScreenRoot
 import com.hegunhee.maplefinder.item.search.ItemSearchScreenRoot
 
+const val SEARCH_ROUTE = "Search_Item"
+
+fun detailRoute(ocid: String) : String {
+    return "${SEARCH_ROUTE}/${ocid}"
+}
+
+fun detailListRoute(ocid : String,slotName : String) : String {
+    return "${SEARCH_ROUTE}/$ocid/$slotName"
+}
+
 fun NavController.navigateItemDetail(ocid : String) {
-    navigate(ItemNavGraph.detailRoute(ocid))
+    navigate(detailRoute(ocid))
 }
 
 fun NavController.navigateItemList(ocid : String,slotName: String) {
-    navigate(ItemNavGraph.detailListRoute(ocid,slotName))
+    navigate(detailListRoute(ocid, slotName))
 }
 fun NavGraphBuilder.itemNavGraph(
     onNavigationIconClick : () -> Unit,
@@ -22,14 +32,14 @@ fun NavGraphBuilder.itemNavGraph(
     onItemListButtonClick : (String,String) -> Unit,
     onItemDetailButtonClick : (String) -> Unit
 ) {
-    composable(route = ItemNavGraph.searchRoute) {
+    composable(route = SEARCH_ROUTE) {
         ItemSearchScreenRoot(
             onNavigationIconClick = onNavigationIconClick,
             onSearchCharacterItemClick = onItemDetailButtonClick
         )
     }
 
-    composable(route = ItemNavGraph.detailRoute("{ocid}"),
+    composable(route = detailRoute("{ocid}"),
         arguments  = listOf(
             navArgument("ocid") {
                 type = NavType.StringType
@@ -42,7 +52,7 @@ fun NavGraphBuilder.itemNavGraph(
             onItemListButtonClick = onItemListButtonClick
         )
     }
-    composable(route = ItemNavGraph.detailListRoute("{ocid}","{slotName}"),
+    composable(route = detailListRoute("{ocid}", "{slotName}"),
         arguments = listOf(
             navArgument("ocid") {
                 type = NavType.StringType
@@ -55,19 +65,5 @@ fun NavGraphBuilder.itemNavGraph(
             slot = slotName,
             popBackStack = onPopBackStack
         )
-    }
-}
-
-object ItemNavGraph {
-    const val searchRoute = "Search"
-
-    private const val listRoute = "List"
-
-    fun detailRoute(ocid : String) : String {
-        return "$searchRoute/$ocid"
-    }
-
-    fun detailListRoute(ocid : String,slotName : String) : String {
-        return "$listRoute/$ocid/$slotName"
     }
 }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
@@ -11,16 +11,16 @@ import com.hegunhee.maplefinder.item.search.ItemSearchScreenRoot
 
 const val SEARCH_ROUTE = "Search_Item"
 
-fun detailRoute(ocid: String) : String {
-    return "${SEARCH_ROUTE}/${ocid}"
+fun detailRoute(ocid: String,date: String) : String {
+    return "${SEARCH_ROUTE}/${ocid}/${date}"
 }
 
 fun detailListRoute(ocid : String,slotName : String) : String {
     return "${SEARCH_ROUTE}/$ocid/$slotName"
 }
 
-fun NavController.navigateItemDetail(ocid : String) {
-    navigate(detailRoute(ocid))
+fun NavController.navigateItemDetail(ocid : String,date: String) {
+    navigate(detailRoute(ocid,date))
 }
 
 fun NavController.navigateItemList(ocid : String,slotName: String) {
@@ -30,7 +30,7 @@ fun NavGraphBuilder.itemNavGraph(
     onNavigationIconClick : () -> Unit,
     onPopBackStack : () -> Unit,
     onItemListButtonClick : (String,String) -> Unit,
-    onItemDetailButtonClick : (String) -> Unit
+    onItemDetailButtonClick : (ocid: String,date: String) -> Unit
 ) {
     composable(route = SEARCH_ROUTE) {
         ItemSearchScreenRoot(
@@ -39,15 +39,17 @@ fun NavGraphBuilder.itemNavGraph(
         )
     }
 
-    composable(route = detailRoute("{ocid}"),
+    composable(route = detailRoute("{ocid}","{date}"),
         arguments  = listOf(
             navArgument("ocid") {
                 type = NavType.StringType
             }
         )){ navBackStackEntry ->
         val ocid = navBackStackEntry.arguments?.getString("ocid") ?: ""
+        val date = navBackStackEntry.arguments?.getString("date") ?: ""
         ItemDetailScreenRoot(
             ocid = ocid,
+            date = date,
             onNavigationIconClick = onNavigationIconClick,
             onItemListButtonClick = onItemListButtonClick
         )

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemNavActions.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemNavActions.kt
@@ -3,6 +3,8 @@ package com.hegunhee.maplefinder.item.search
 sealed interface ItemNavActions {
 
     data class Detail(
-        val ocid : String
+        val ocid: String,
+        val date: String,
     ) : ItemNavActions
+
 }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchRoot.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchRoot.kt
@@ -26,17 +26,19 @@ import com.hegunhee.maplefinder.util.SelectedDateFormatUtil.toTimeMills
 @Composable
 fun ItemSearchScreenRoot(
     viewModel: ItemSearchViewModel = hiltViewModel(),
-    onNavigationIconClick : () -> Unit,
-    onSearchCharacterItemClick : (ocid: String, date: String) -> Unit,
+    onNavigationIconClick: () -> Unit,
+    onSearchCharacterItemClick: (ocid: String, date: String) -> Unit,
 ) {
-    val searchQuery = viewModel.searchQuery.collectAsStateWithLifecycle().value
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+
+    val (searchQuery, onQueryChanged) = remember { mutableStateOf("") }
     val (searchDate, onDateSelected) = rememberSaveable { mutableStateOf(defaultDateString()) }
+
     LaunchedEffect(true) {
         viewModel.navActions.collect {
-            when(it) {
+            when (it) {
                 is ItemNavActions.Detail -> {
-                    onSearchCharacterItemClick(it.ocid,searchDate)
+                    onSearchCharacterItemClick(it.ocid, it.date)
                 }
             }
         }
@@ -48,7 +50,7 @@ fun ItemSearchScreenRoot(
         searchDate = searchDate,
         onNavigationIconClick = onNavigationIconClick,
         onSearchCharacterItemClick = viewModel::characterOcidSearch,
-        onQueryChange = viewModel::onQueryChange,
+        onQueryChange = onQueryChanged,
         onDateSelected = onDateSelected
     )
 }
@@ -57,12 +59,12 @@ fun ItemSearchScreenRoot(
 @Composable
 private fun ItemSearchScreen(
     uiState: ItemSearchUiState,
-    searchQuery : String,
-    searchDate : String,
+    searchQuery: String,
+    searchDate: String,
     onNavigationIconClick: () -> Unit,
-    onSearchCharacterItemClick : (name: String,date: String) -> Unit,
-    onQueryChange : (String) -> Unit,
-    onDateSelected : (String) -> Unit,
+    onSearchCharacterItemClick: (name: String, date: String) -> Unit,
+    onQueryChange: (String) -> Unit,
+    onDateSelected: (String) -> Unit,
 ) {
     val (showDateDialog, onDatePickerValueChange) = remember { mutableStateOf(false) }
     if (showDateDialog) {
@@ -74,10 +76,12 @@ private fun ItemSearchScreen(
     }
     val keyboardController = LocalSoftwareKeyboardController.current
     Scaffold(
-        topBar = { MapleTopBar(
-            title = "캐릭터 아이템 조회",
-            onNavigationIconClick = onNavigationIconClick
-        ) }
+        topBar = {
+            MapleTopBar(
+                title = "캐릭터 아이템 조회",
+                onNavigationIconClick = onNavigationIconClick
+            )
+        }
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -89,11 +93,11 @@ private fun ItemSearchScreen(
                 date = searchDate,
                 onSearchCharacterClick = onSearchCharacterItemClick,
                 onQueryChange = onQueryChange,
-                onDatePickerShowClick = { onDatePickerValueChange(true)},
+                onDatePickerShowClick = { onDatePickerValueChange(true) },
                 keyboardController = keyboardController,
             )
             Spacer(modifier = Modifier.padding(vertical = 10.dp))
-            if(uiState is ItemSearchUiState.Error) {
+            if (uiState is ItemSearchUiState.Error) {
                 ErrorSurface(exception = uiState.throwable)
             }
         }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchRoot.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchRoot.kt
@@ -27,7 +27,7 @@ import com.hegunhee.maplefinder.util.SelectedDateFormatUtil.toTimeMills
 fun ItemSearchScreenRoot(
     viewModel: ItemSearchViewModel = hiltViewModel(),
     onNavigationIconClick : () -> Unit,
-    onSearchCharacterItemClick : (String) -> Unit,
+    onSearchCharacterItemClick : (ocid: String, date: String) -> Unit,
 ) {
     val searchQuery = viewModel.searchQuery.collectAsStateWithLifecycle().value
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
@@ -36,7 +36,7 @@ fun ItemSearchScreenRoot(
         viewModel.navActions.collect {
             when(it) {
                 is ItemNavActions.Detail -> {
-                    onSearchCharacterItemClick(it.ocid)
+                    onSearchCharacterItemClick(it.ocid,searchDate)
                 }
             }
         }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchUiState.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchUiState.kt
@@ -5,6 +5,7 @@ sealed interface ItemSearchUiState {
     object Loading : ItemSearchUiState
 
     data class Error(
-        val throwable : Throwable
+        val throwable: Throwable
     ) : ItemSearchUiState
+
 }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchViewModel.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/search/ItemSearchViewModel.kt
@@ -18,20 +18,17 @@ class ItemSearchViewModel @Inject constructor(
     private val getCharacterOcidUseCase: GetCharacterOcidUseCase
 ) : ViewModel() {
 
-    private val _navActions : MutableSharedFlow<ItemNavActions> = MutableSharedFlow()
-    val navActions : SharedFlow<ItemNavActions> = _navActions.asSharedFlow()
+    private val _navActions: MutableSharedFlow<ItemNavActions> = MutableSharedFlow()
+    val navActions: SharedFlow<ItemNavActions> = _navActions.asSharedFlow()
 
-    private val _uiState : MutableStateFlow<ItemSearchUiState> = MutableStateFlow(ItemSearchUiState.Loading)
-    val uiState : StateFlow<ItemSearchUiState> = _uiState.asStateFlow()
+    private val _uiState: MutableStateFlow<ItemSearchUiState> = MutableStateFlow(ItemSearchUiState.Loading)
+    val uiState: StateFlow<ItemSearchUiState> = _uiState.asStateFlow()
 
-    private val _searchQuery : MutableStateFlow<String> = MutableStateFlow("")
-    val searchQuery : StateFlow<String> = _searchQuery.asStateFlow()
-
-    fun characterOcidSearch(characterName : String,searchDate: String) {
+    fun characterOcidSearch(characterName: String, searchDate: String) {
         viewModelScope.launch {
             getCharacterOcidUseCase(characterName)
                 .onSuccess { ocid ->
-                    _navActions.emit(ItemNavActions.Detail(ocid.id))
+                    _navActions.emit(ItemNavActions.Detail(ocid.id, searchDate))
                     _uiState.value = ItemSearchUiState.Loading
                 }.onFailure {
                     _uiState.value = ItemSearchUiState.Error(it)
@@ -39,7 +36,4 @@ class ItemSearchViewModel @Inject constructor(
         }
     }
 
-    fun onQueryChange(query : String) {
-        _searchQuery.value = query
-    }
 }

--- a/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
+++ b/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
@@ -37,10 +37,10 @@ import com.hegunhee.maplefinder.character_info.navigation.CHARACTER_INFO_ROUTE
 import com.hegunhee.maplefinder.character_info.navigation.infoNavGraph
 import com.hegunhee.maplefinder.dojang_record.DojangNavGraph
 import com.hegunhee.maplefinder.dojang_record.dojangNavGraph
-import com.hegunhee.maplefinder.item.ItemNavGraph
-import com.hegunhee.maplefinder.item.itemNavGraph
-import com.hegunhee.maplefinder.item.navigateItemDetail
-import com.hegunhee.maplefinder.item.navigateItemList
+import com.hegunhee.maplefinder.item.navigation.SEARCH_ROUTE
+import com.hegunhee.maplefinder.item.navigation.itemNavGraph
+import com.hegunhee.maplefinder.item.navigation.navigateItemDetail
+import com.hegunhee.maplefinder.item.navigation.navigateItemList
 
 @Composable
 fun MapleApp(
@@ -173,7 +173,7 @@ enum class DrawerItem(
         group = DrawerGroup.Personal,
         titleString = "착용장비 정보 조회",
         iconRes = com.hegunhee.maplefinder.designsystem.R.drawable.work_gloves,
-        navRoute = ItemNavGraph.searchRoute
+        navRoute = SEARCH_ROUTE
     ),
     Dojang(
         group = DrawerGroup.Personal,

--- a/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
+++ b/feature/main/src/main/java/com/hegunhee/maplefinder/main/MapleApp.kt
@@ -103,8 +103,8 @@ class MapleAppScaffoldState(
         }
     }
 
-    fun navigateItemDetail(ocid: String) {
-        navController.navigateItemDetail(ocid)
+    fun navigateItemDetail(ocid: String,date: String) {
+        navController.navigateItemDetail(ocid,date)
     }
 
     fun navigateItemList(ocid: String, slotName: String) {


### PR DESCRIPTION
아이템 검색 화면을 리팩터링했다.
날짜 선택칸을 추가했고 날짜 정보도 아이템 상세 화면에 넘겨줬다.
검색쿼리나 날짜값의 경우 ViewModel이 아닌 ScreenRoute에 선언하였다.

This closes #50 