### PR TITLE
아이템 상세보기 이동시 팅기는 오류 수정

### DIFF
--- a/core/util/src/main/java/com/hegunhee/maplefinder/util/SelectedDateFormatUtil.kt
+++ b/core/util/src/main/java/com/hegunhee/maplefinder/util/SelectedDateFormatUtil.kt
@@ -36,7 +36,20 @@ object SelectedDateFormatUtil {
         return LocalDate.parse(this, DateFormat).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli()
     }
 
+    fun String?.toDateFormat() : String? {
+        val result = runCatching {
+            LocalDate.parse(this, longDateFormat)
+        }
+        return if(result.isSuccess) {
+            LocalDate.parse(this, longDateFormat).format(DateFormat)
+        } else {
+            this
+        }
+    }
+
     private val yesterdayDate = LocalDateTime.now().minusDays(1)
     private val startDate = LocalDateTime.of(2023,12,22,0,0)
     private val DateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    private val longDateFormat = DateTimeFormatter.ISO_DATE_TIME
+
 }

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailRoot.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailRoot.kt
@@ -21,8 +21,9 @@ fun ItemDetailScreenRoot(
     onNavigationIconClick : () -> Unit,
     onItemListButtonClick : (String,String) -> Unit
 ) {
+    date
     LaunchedEffect(key1 = viewModel.uiState) {
-        viewModel.fetchItemData(ocid)
+        viewModel.fetchItemData(ocid,date)
     }
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     ItemDetailScreen(

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailViewModel.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/detail/ItemDetailViewModel.kt
@@ -18,9 +18,9 @@ class ItemDetailViewModel @Inject constructor(
     private val _uiState : MutableStateFlow<ItemDetailUiState> = MutableStateFlow(ItemDetailUiState.Loading)
     val uiState : StateFlow<ItemDetailUiState> = _uiState.asStateFlow()
 
-    fun fetchItemData(ocid : String) {
+    fun fetchItemData(ocid : String,date: String) {
         viewModelScope.launch {
-            getCharacterEquipmentItem(ocid,date = "2024-03-03")
+            getCharacterEquipmentItem(ocid,date = date)
                 .onSuccess {
                     _uiState.value = ItemDetailUiState.Success(it)
                 }.onFailure {

--- a/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
+++ b/feature/item/src/main/java/com/hegunhee/maplefinder/item/navigation/ItemNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.navArgument
 import com.hegunhee.maplefinder.item.detail.ItemDetailScreenRoot
 import com.hegunhee.maplefinder.item.list.ItemListScreenRoot
 import com.hegunhee.maplefinder.item.search.ItemSearchScreenRoot
+import com.hegunhee.maplefinder.util.SelectedDateFormatUtil.toDateFormat
 
 const val SEARCH_ROUTE = "Search_Item"
 
@@ -46,7 +47,7 @@ fun NavGraphBuilder.itemNavGraph(
             }
         )){ navBackStackEntry ->
         val ocid = navBackStackEntry.arguments?.getString("ocid") ?: ""
-        val date = navBackStackEntry.arguments?.getString("date") ?: ""
+        val date = navBackStackEntry.arguments?.getString("date").toDateFormat() ?: ""
         ItemDetailScreenRoot(
             ocid = ocid,
             date = date,


### PR DESCRIPTION
아이템 상세화면에서 날짜값을 받는데
아이템 검색과 캐릭터 검색에서 받는 포맷값이 달라서 앱이 죽어버렸다.

해당 이슈를 수정했다.

This closes #52 