### PR TITLE
어빌리티 프리셋이 세번째 프리셋을 가리킬경우 앱이 죽는현상 수정

### DIFF
--- a/core/data/src/main/java/com/hegunhee/maplefinder/data/mapper/CharacterMapper.kt
+++ b/core/data/src/main/java/com/hegunhee/maplefinder/data/mapper/CharacterMapper.kt
@@ -106,7 +106,7 @@ fun CharacterHyperStatResponse.toModel(): CharacterHyperStat {
         currentPreset = hyperStatList[currentPresetNum.toInt() - 1],
         hyperStatPresetList = hyperStatList,
         remainHyperStat = remainHyperStat,
-        currentPresetNum = currentPresetNum
+        currentPresetNum = (currentPresetNum.toInt() -1).toString()
     )
 }
 
@@ -119,7 +119,7 @@ fun CharacterAbilityResponse.toModel(): CharacterAbility {
             abilityPreset2,
             abilityPreset3
         ).map { it?.toModel() },
-        presetNo = presetNo ?: 1,
+        presetNo = presetNo?.minus(1) ?: 0,
         remainFame = remainFame
     )
 }


### PR DESCRIPTION
프리셋 넘버가 1~3의 범위를 가지니 최대 프리셋의 인덱스가 2라서
API에서 내려오는 값이 마지막 프리셋을 가리킬경우 앱이 뻗어버림

This closes #69 