### PR TITLE
api key 누락 exception이 캐릭터가 존재 안하는 excpetion으로 발생하던것 수정 #82

### DIFF
--- a/core/data/src/main/java/com/hegunhee/maplefinder/data/api/createResult.kt
+++ b/core/data/src/main/java/com/hegunhee/maplefinder/data/api/createResult.kt
@@ -1,8 +1,11 @@
 package com.hegunhee.maplefinder.data.api
 
+import com.hegunhee.maplefinder.data.api.model.error.ErrorDetail
+import com.hegunhee.maplefinder.data.api.model.error.ErrorResponse
 import com.hegunhee.maplefinder.model.exception.NexonApiException
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -14,7 +17,10 @@ suspend fun <T, R> T.createResult(call : suspend T.() -> R) : Result<R> {
             500 -> { NexonApiException.ServerException }
             429 -> { NexonApiException.TooManyRequestException }
             403 -> { NexonApiException.ForbiddenException }
-            400 -> { NexonApiException.InvailedParameterException }
+            400 -> {
+                val errorResponse = json.decodeFromString<ErrorResponse>(httpE.getJsonErrorBodyString())
+                create400CustomException(errorResponse.errorDetail)
+            }
             else -> { httpE }
         })
     } catch (missingFieldE: MissingFieldException) {
@@ -24,4 +30,28 @@ suspend fun <T, R> T.createResult(call : suspend T.() -> R) : Result<R> {
     } catch (e: Throwable) {
         Result.failure(e)
     }
+}
+
+private fun HttpException.getJsonErrorBodyString(): String{
+    return response()?.errorBody()?.string() ?: ""
+}
+
+private fun create400CustomException(errorDetail: ErrorDetail): NexonApiException {
+    return when (errorDetail.name) {
+        "OPENAPI00005" -> {
+            NexonApiException.InvailedApiKeyException
+        }
+        "OPENAPI00004" -> {
+            NexonApiException.InvailedParameterException
+        }
+        else -> {
+            NexonApiException.IllegalStateException
+        }
+    }
+}
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    coerceInputValues = true
 }

--- a/core/data/src/main/java/com/hegunhee/maplefinder/data/api/model/error/ErrorDetail.kt
+++ b/core/data/src/main/java/com/hegunhee/maplefinder/data/api/model/error/ErrorDetail.kt
@@ -1,0 +1,10 @@
+package com.hegunhee.maplefinder.data.api.model.error
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ErrorDetail(
+    @SerialName("name") val name: String,
+    @SerialName("message") val message: String,
+)

--- a/core/data/src/main/java/com/hegunhee/maplefinder/data/api/model/error/ErrorResponse.kt
+++ b/core/data/src/main/java/com/hegunhee/maplefinder/data/api/model/error/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.hegunhee.maplefinder.data.api.model.error
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ErrorResponse(
+    @SerialName("error") val errorDetail: ErrorDetail,
+)

--- a/core/model/src/main/java/com/hegunhee/maplefinder/model/exception/NexonException.kt
+++ b/core/model/src/main/java/com/hegunhee/maplefinder/model/exception/NexonException.kt
@@ -12,6 +12,8 @@ sealed class NexonApiException(val code : Int, override val message : String) : 
 
     object InvailedApiKeyException : NexonApiException(code = 400, message = "api key가 유효하지 않습니다.")
 
+    object IllegalStateException : NexonApiException(code = 400, message = "알수없는 네트워크 에러가 발생했습니다.")
+
     object UnretrivableException : NexonApiException(code = 404, message = "존재하지만 조회가 불가능합니다.")
     
 }

--- a/core/model/src/main/java/com/hegunhee/maplefinder/model/exception/NexonException.kt
+++ b/core/model/src/main/java/com/hegunhee/maplefinder/model/exception/NexonException.kt
@@ -10,6 +10,8 @@ sealed class NexonApiException(val code : Int, override val message : String) : 
 
     object InvailedParameterException : NexonApiException(code = 400, message = "캐릭터 이름이 유효하지 않습니다")
 
+    object InvailedApiKeyException : NexonApiException(code = 400, message = "api key가 유효하지 않습니다.")
+
     object UnretrivableException : NexonApiException(code = 404, message = "존재하지만 조회가 불가능합니다.")
     
 }


### PR DESCRIPTION
api key 누락시 캐릭터 이름이 이상한것과 같은 예외를 반환하기때문에
네트워크 에러를 파싱해서 커스텀 예외로 변환함

This closes #82 