### PR TITLE
다크테마에서 글씨가 검정색으로 나오는 문제 수정

### DIFF
--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/CharacterSurface.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/CharacterSurface.kt
@@ -75,7 +75,7 @@ fun CharacterHeader(
         Column {
             Spacer(modifier = Modifier.size(10.dp))
             Row {
-                Text(characterBasic.name, fontSize = 20.sp, fontStyle = FontStyle.Normal,color = Color.Black)
+                Text(characterBasic.name, fontSize = 20.sp, fontStyle = FontStyle.Normal)
                 Spacer(modifier = Modifier.size(5.dp))
                 WorldTag(world = characterBasic.world)
             }

--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/AbilityPreset.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/AbilityPreset.kt
@@ -35,7 +35,6 @@ fun AbilityPreset(
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = "어빌리티",
-            color = Color.Black,
             textAlign = TextAlign.Center,
             fontSize = 20.sp
         )

--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/DetailStat.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/DetailStat.kt
@@ -23,7 +23,6 @@ fun DetailStat(
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = "전투력 : ${stat.powerLevel}",
-            color = Color.Black,
             textAlign = TextAlign.Center,
             fontSize = 20.sp
         )

--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/HyperStat.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/surface/stat/HyperStat.kt
@@ -25,7 +25,6 @@ fun HyperStat(
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = "하이퍼 스텟",
-            color = Color.Black,
             textAlign = TextAlign.Center,
             fontSize = 20.sp
         )

--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/text/DetailItemOption.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/text/DetailItemOption.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,7 +27,7 @@ internal fun DetailOptionText(
     starforceOptionValue : Int?
 ) {
     val optionList : List<Int?> = listOf(baseOptionValue,addOptionValue,scrollOptionValue,starforceOptionValue)
-    val colorList : List<Color> = listOf(Color.Black, Cyan, PurpleWhite, MapleOrange)
+    val colorList : List<Color> = listOf(LocalContentColor.current, Cyan, PurpleWhite, MapleOrange)
     Row {
         if(addOptionValue == null && scrollOptionValue == null && starforceOptionValue ==null) {
             Text(text = "$key : +$value")


### PR DESCRIPTION
다크테마에서 글씨가 검정색으로 나오는 문제를 수정했다.

딱히 글자 색상을 지정해주지 않았다. (테마에 따라서 기본 색상이 적용되도록)
아이템 옵션의 세부적인 옵션에서는 직접 기본 색상을 적용해줬다.

This closes #87 