### PR TITLE
 스타포스가 최대 30성까지 확장되어서 앱 UI 수정

### DIFF
--- a/core/data/src/main/java/com/hegunhee/maplefinder/data/mapper/ItemMapper.kt
+++ b/core/data/src/main/java/com/hegunhee/maplefinder/data/mapper/ItemMapper.kt
@@ -120,7 +120,7 @@ private fun cubeOptionToModel(
 
 internal fun starMaxCount(itemLevel: Int): Int {
     return when (itemLevel) {
-        in 138..300 -> 25
+        in 138..300 -> 300
         in 128..137 -> 20
         in 118..127 -> 15
         in 108..117 -> 10

--- a/core/ui/src/main/java/com/hegunhee/maplefinder/ui/tag/StarforceTag.kt
+++ b/core/ui/src/main/java/com/hegunhee/maplefinder/ui/tag/StarforceTag.kt
@@ -93,7 +93,7 @@ internal fun StarforceHeader(
         }
         if (maxStarCount > 15) {
             Row(modifier = Modifier.fillMaxWidth(),horizontalArrangement = Arrangement.Center){
-                for (i in 16 .. 25) {
+                for (i in 16 .. 30) {
                     if (i <= maxStarCount) {
                         StarIcon(
                             modifier = starModifier,


### PR DESCRIPTION
아이템 레벨이 138이 넘으면 최대 별 갯수를 30개로 지정해줬다.

This closes #89 